### PR TITLE
updated cc-tool version, and fixed makefile

### DIFF
--- a/cc-tool.rb
+++ b/cc-tool.rb
@@ -2,17 +2,33 @@ require 'formula'
 
 class CcTool < Formula
   homepage 'http://cctool.sourceforge.net/'
-  url 'http://downloads.sourceforge.net/project/cctool/cc-tool-0.24-src.tgz'
-  sha1 'c10c0d7652769ed754c549fd5f428a3519a4a78f'
+  url 'http://downloads.sourceforge.net/project/cctool/cc-tool-0.26-src.tgz'
+  sha1 'f313e55f019ea5338438633f5b5e689b699343e1'
 
   depends_on 'libusb'
   depends_on 'boost'
   depends_on 'pkg-config' => :build
 
+  # Fix makefile
+  patch :DATA
+
   def install
-    system "./configure", "--disable-debug", "--disable-dependency-tracking",
-                          "--prefix=#{prefix}"
+    system "./configure", "--prefix=#{prefix}"
     system "make"
     system "make install"
   end
 end
+
+__END__
+diff -uNr a/Makefile.in b/Makefile.in
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -224,7 +224,7 @@
+ LD = @LD@
+ LDFLAGS = @LDFLAGS@
+ LIBOBJS = @LIBOBJS@
+-LIBS = -s \
++LIBS = \
+ 	$(BOOST_FILESYSTEM_LIBS) \
+ 	$(BOOST_REGEX_LIBS) \
+ 	$(BOOST_SYSTEM_LIBS) \


### PR DESCRIPTION
While updating a local formula for cc-tool, building was failing for me on Yosimite. I got the make to work, and I stumbled on someone in your issues list that was having a similar issue. The makefile change I needed for the formula turns out to be the same that's needed for yours.

This patch should solve the issue here:
[https://github.com/darconeous/homebrew-embedded/issues/6](https://github.com/darconeous/homebrew-embedded/issues/6)

Hope this helps.
