### PR TITLE
Correct deprecated sha1

### DIFF
--- a/arm-2008q3-binutils.rb
+++ b/arm-2008q3-binutils.rb
@@ -3,7 +3,8 @@ require 'formula'
 class Arm2008q3Binutils < Formula
 	homepage 'http://gcc.gnu.org'
 	url 'http://ftp.gnu.org/gnu/binutils/binutils-2.18.tar.bz2'
-	sha1 '0697d6f99ec0745567a5acfa7e4e31bcc9ef8698'
+	#sha1 '0697d6f99ec0745567a5acfa7e4e31bcc9ef8698'
+   sha256 '4515254f55ec3d8c4d91e7633f3850ff28f60652b2d90dc88eef47c74c194bc9'
 
 	def install
 #		ENV['CC'] = 'llvm-gcc-4.2'

--- a/arm-2008q3-gcc.rb
+++ b/arm-2008q3-gcc.rb
@@ -4,7 +4,8 @@ class Arm2008q3Gcc < Formula
   homepage 'http://gcc.gnu.org'
   url 'http://ftpmirror.gnu.org/gcc/gcc-4.3.2/gcc-4.3.2.tar.bz2'
   mirror 'http://ftp.gnu.org/gnu/gcc/gcc-4.3.2/gcc-4.3.2.tar.bz2'
-  sha1 '787b566ad4f386a9896e2d5703e6ff5e7ccaca58'
+  #sha1 '787b566ad4f386a9896e2d5703e6ff5e7ccaca58'
+  sha256 'bfbf487731ad5dca37efe480a837417de071bd67e685d5c1df6a290707575165'
 
   depends_on 'gmp'
   depends_on 'libmpc'

--- a/arm-2008q3-newlib.rb
+++ b/arm-2008q3-newlib.rb
@@ -3,7 +3,8 @@ require 'formula'
 class Arm2008q3Newlib < Formula
   url 'ftp://sources.redhat.com/pub/newlib/newlib-1.16.0.tar.gz'
   homepage 'http://sourceware.org/newlib/'
-  sha1 '841edec33d19a9e549984982fb92445ee967e265'
+  #sha1 '841edec33d19a9e549984982fb92445ee967e265'
+  sha256 'db426394965c48c1d29023e1cc6d965ea6b9a9035d8a849be2750ca4659a3d07'
 
   def install
     onoe "This version of newlib is not directly installable. You probably want to install arm-2008q3-gcc instead."

--- a/arm-none-eabi-binutils.rb
+++ b/arm-none-eabi-binutils.rb
@@ -4,7 +4,8 @@ class ArmNoneEabiBinutils < Formula
     homepage 'http://gcc.gnu.org'
 
     url 'http://ftp.gnu.org/gnu/binutils/binutils-2.23.tar.gz'
-    sha1 '470c388c97ac8d216de33fa397d7be9f96c3fe04'
+    #sha1 '470c388c97ac8d216de33fa397d7be9f96c3fe04'
+    sha256 '7909a08eabdbaac0f7a22e9ede82a66ba70acd50629b045e705af864eef10b65'
 #    url 'http://ftp.gnu.org/gnu/binutils/binutils-2.22.tar.gz'
 #    sha1 '0e16a7492c0a194962ecd33fc80fa53ccfec5149'
 

--- a/arm-none-eabi-gcc.rb
+++ b/arm-none-eabi-gcc.rb
@@ -5,7 +5,8 @@ class ArmNoneEabiGcc < Formula
 
   url 'http://ftpmirror.gnu.org/gcc/gcc-4.8.2/gcc-4.8.2.tar.bz2'
   mirror 'http://ftp.gnu.org/gnu/gcc/gcc-4.8.2/gcc-4.8.2.tar.bz2'
-  sha1 '810fb70bd721e1d9f446b6503afe0a9088b62986'
+  #sha1 '810fb70bd721e1d9f446b6503afe0a9088b62986'
+  sha256 '09dc2276c73424bbbfda1dbddc62bbbf900c9f185acf7f3e1d773ce2d7e3cdc8'
 
   depends_on 'gmp'
   depends_on 'libmpc'

--- a/avarice.rb
+++ b/avarice.rb
@@ -3,7 +3,8 @@ require 'formula'
 class Avarice < Formula
   homepage 'http://http://avarice.sourceforge.net/'
   url 'http://downloads.sourceforge.net/project/avarice/avarice/avarice-2.13/avarice-2.13.tar.bz2'
-  sha1 'b0bc56d587600651c0e61be676177b2eebfad3ae'
+  #sha1 'b0bc56d587600651c0e61be676177b2eebfad3ae'
+  sha256 'a14738fe78e1a0a9321abcca7e685a00ce3ced207622ccbcd881ac32030c104a'
 
   depends_on 'libusb'
 

--- a/avr-binutils.rb
+++ b/avr-binutils.rb
@@ -4,7 +4,8 @@ class AvrBinutils < Formula
   url 'http://ftpmirror.gnu.org/binutils/binutils-2.23.1.tar.bz2'
   mirror 'http://ftp.gnu.org/gun/binutils/binutils-2.23.1.tar.bz2'
   homepage 'http://www.gnu.org/software/binutils/binutils.html'
-  sha1 '587fca86f6c85949576f4536a90a3c76ffc1a3e1'
+  #sha1 '587fca86f6c85949576f4536a90a3c76ffc1a3e1'
+  sha256 '2ab2e5b03e086d12c6295f831adad46b3e1410a3a234933a2e8fac66cb2e7a19'
 
   option 'disable-libbfd', 'Disable installation of libbfd.'
 

--- a/avr-gcc.rb
+++ b/avr-gcc.rb
@@ -11,7 +11,8 @@ class AvrGcc < Formula
   homepage 'http://gcc.gnu.org'
   url 'http://ftpmirror.gnu.org/gcc/gcc-4.8.1/gcc-4.8.1.tar.bz2'
   mirror 'http://ftp.gnu.org/gnu/gcc/gcc-4.8.1/gcc-4.8.1.tar.bz2'
-  sha1 '4e655032cda30e1928fcc3f00962f4238b502169'
+  #sha1 '4e655032cda30e1928fcc3f00962f4238b502169'
+  sha256 '545b44be3ad9f2c4e90e6880f5c9d4f0a8f0e5f67e1ffb0d45da9fa01bb05813'
 
   depends_on 'gmp'
   depends_on 'libmpc'

--- a/avr-gdb.rb
+++ b/avr-gdb.rb
@@ -4,7 +4,8 @@ class AvrGdb < Formula
   homepage 'http://gcc.gnu.org'
   url 'http://ftpmirror.gnu.org/gdb/gdb-7.7.tar.gz'
   mirror 'http://ftp.gnu.org/gnu/gdb/gdb-7.7.tar.gz'
-  sha1 '5cdc83ada4fe2a37d775c36272187f08b95bebe6'
+  #sha1 '5cdc83ada4fe2a37d775c36272187f08b95bebe6'
+  sha256 '8814d98c2733639cb602b6ecd8d69e02498017e02b5724c9451c285b0e9ee173'
 
   depends_on 'avr-binutils'
 

--- a/cc-tool.rb
+++ b/cc-tool.rb
@@ -3,7 +3,8 @@ require 'formula'
 class CcTool < Formula
   homepage 'http://cctool.sourceforge.net/'
   url 'http://downloads.sourceforge.net/project/cctool/cc-tool-0.26-src.tgz'
-  sha1 'f313e55f019ea5338438633f5b5e689b699343e1'
+  #sha1 'f313e55f019ea5338438633f5b5e689b699343e1'
+  sha256 'f313e55f019ea5338438633f5b5e689b699343e1'
 
   depends_on 'libusb'
   depends_on 'boost'

--- a/newlib.rb
+++ b/newlib.rb
@@ -6,7 +6,8 @@ class Newlib < Formula
   #sha1 'ea6b5727162453284791869e905f39fb8fab8d3f'
 
   url 'ftp://sources.redhat.com/pub/newlib/newlib-1.19.0.tar.gz'
-  sha1 'b2269d30ce7b93b7c714b90ef2f40221c2df0fcd'
+  #sha1 'b2269d30ce7b93b7c714b90ef2f40221c2df0fcd'
+  sha256 '4f43807236b2274c220881ca69f7dc6aecc52f14bb32a6f03404d30780c25007'
 
   def install
     system "./configure", "--disable-debug", "--disable-dependency-tracking",

--- a/sdcc.rb
+++ b/sdcc.rb
@@ -4,7 +4,8 @@ class Sdcc < Formula
   homepage 'http://sdcc.sourceforge.net/'
   head 'https://sdcc.svn.sourceforge.net/svnroot/sdcc/trunk/sdcc/'
   url 'http://downloads.sourceforge.net/project/sdcc/sdcc/3.1.0/sdcc-src-3.1.0.tar.bz2'
-  sha1 '4806c79bd1572c3be8e8a9ee68f94c31d251d530'
+  #sha1 '4806c79bd1572c3be8e8a9ee68f94c31d251d530'
+  sha256 'e8802e79b0247bbb51dec49047a2247ad4da1d89cf1aefd49e35d65aee91d185'
 
   depends_on 'gputils'
   depends_on 'boost'

--- a/smcp.rb
+++ b/smcp.rb
@@ -4,7 +4,7 @@ class Smcp < Formula
   homepage 'https://github.com/darconeous/smcp'
   url 'https://github.com/darconeous/smcp.git', :tag => '0.6.5-release'
   head 'https://github.com/darconeous/smcp.git', :using => :git, :branch => 'master'
-  sha1 '3ee78de83293b43aa2a7c7396cef60d82929f98e'
+  #sha1 '3ee78de83293b43aa2a7c7396cef60d82929f98e'
   version '0.6.5'
 
   if build.head?


### PR DESCRIPTION
Fixed the formulas to work with the lastest version of brew.

I was getting errors across the board:

Calling Formula.sha1 is disabled!
Use Formula.sha256 instead.
